### PR TITLE
Optionally allow conntrackd on L3 Agents

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -400,6 +400,11 @@ neutron_legacy_ha_tool_enabled: false
 neutron_ha_vrrp_auth_type: PASS
 neutron_l3_ha_net_cidr: 169.254.192.0/18
 
+# Install/remove conntrackd on L3 Agents. The default conntrackd service
+# is disabled in any case. Valid values are 'absent', 'present'. The package
+# installation honors `neutron_package_state`.
+neutron_l3_conntrackd: 'absent'
+
 ###
 ### DHCP Agent Plugin Configuration
 ###

--- a/tasks/neutron_install.yml
+++ b/tasks/neutron_install.yml
@@ -45,6 +45,35 @@
   retries: 5
   delay: 2
   with_items: "{{ neutron_remove_distro_packages }}"
+  # Exclude conntrackd from the "known problem packages" list on L3 agents, if
+  # we actually want it installed.
+  when: '
+      (neutron_l3_conntrackd == "present" and "neutron_l3_agent" in group_names)
+      | ternary(item != "conntrackd", True)
+    '
+
+- name: Install conntrackd on L3 Agent
+  package:
+    name: conntrackd
+    state: "{{
+        (neutron_l3_conntrackd == 'present')
+        | ternary(neutron_package_state, 'absent')
+      }}"
+  register: install_conntrackd
+  until: install_conntrackd is success
+  retries: 5
+  delay: 2
+  when:
+    - '"neutron_l3_agent" in group_names'
+
+- name: Stop default conntrackd service on L3 Agent
+  systemd:
+    name: conntrackd.service
+    state: stopped
+    enabled: no
+  when:
+    - 'neutron_l3_conntrackd == "present"'
+    - '"neutron_l3_agent" in group_names'
 
 - name: Install the python venv
   import_role:


### PR DESCRIPTION
This is used for our vRouter implementation that relies on conntrackd. By default, this is disabled.