### PR TITLE
Ensure consistent ordering of network_mappings

### DIFF
--- a/library/provider_networks
+++ b/library/provider_networks
@@ -347,7 +347,9 @@ def main():
             'network_geneve_ranges_list': pnp.network_geneve_ranges,
             'network_flat_networks': ','.join(pnp.network_flat_networks),
             'network_flat_networks_list': pnp.network_flat_networks,
-            'network_mappings': ','.join(list(set(pnp.network_mappings))),
+            'network_mappings': ','.join(
+                sorted(list(set(pnp.network_mappings)))
+            ),
             'network_mappings_list': pnp.network_mappings,
             'network_types': ','.join(pnp.network_types),
             'network_sriov_mappings': ','.join(pnp.network_sriov_mappings),


### PR DESCRIPTION
The provider_networks module returned the network_mappings in a random order changing with every invocation. This returns the entries sorted and adds a test to ensure the ordering is consistent between invocations.

This is the same change as commit
4d4903e2091a73729cbaacb71df9daf95dd7ac7d in openstack-ansible-plugins. This change in the os_neutron role is required until Xena. Since Yoga the version in openstack-ansible-plugins (aka openstack.osa collection) is used.

This commit is not upstreamed as the relevant code is no longer present in upstream master.